### PR TITLE
Added ability to terminate the job monitor thread once stop is called.

### DIFF
--- a/src/main/java/org/janelia/cluster/JobMonitor.java
+++ b/src/main/java/org/janelia/cluster/JobMonitor.java
@@ -19,9 +19,11 @@ public class JobMonitor {
 
     // Constants
     private static final int DEFAULT_CHECK_INTERVAL_SECONDS = 15;
+    private static final boolean DEFAULT_KEEP_THREAD_ALIVE = true;
 
     // Configuration
     private final int checkIntervalSeconds;
+    private final boolean keepThreadAlive;
 
     // State
     private JobManager jobManager;
@@ -31,12 +33,21 @@ public class JobMonitor {
 
 
     public JobMonitor(JobManager jobManager) {
-        this(jobManager, DEFAULT_CHECK_INTERVAL_SECONDS);
+        this(jobManager, DEFAULT_CHECK_INTERVAL_SECONDS, DEFAULT_KEEP_THREAD_ALIVE);
     }
 
     public JobMonitor(JobManager jobManager, int checkIntervalSeconds) {
+        this(jobManager, checkIntervalSeconds, DEFAULT_KEEP_THREAD_ALIVE);
+    }
+
+    public JobMonitor(JobManager jobManager, boolean keepThreadAlive) {
+        this(jobManager, DEFAULT_CHECK_INTERVAL_SECONDS, keepThreadAlive);
+    }
+
+    public JobMonitor(JobManager jobManager, int checkIntervalSeconds, boolean keepThreadAlive) {
         this.jobManager = jobManager;
         this.checkIntervalSeconds = checkIntervalSeconds;
+        this.keepThreadAlive = keepThreadAlive;
     }
 
     /**
@@ -55,14 +66,17 @@ public class JobMonitor {
     }
 
     /**
-     * Stop monitoring the cluster. After calling stop(), the client may call start() to begin monitoring again.
-     * If the monitor is not running, calling this method does nothing.
+     * Stop monitoring the cluster. If keepThreadAlive==false: After calling stop(), the client may call start() to begin monitoring again.
+     * If the monitor is not running, calling this method does nothing. If keepThreadAlive==true: After calling stop(), the client cannot call start() again, because the thread will die.
      */
     public synchronized void stop() {
         if (started) {
             log.debug("Stopping job monitoring");
             jobChecker.cancel(true);
             started = false;
+            if (!this.keepThreadAlive) {
+                this.scheduler.shutdown();
+            }
         }
     }
 }


### PR DESCRIPTION
The job monitor thread prevented the JVM from exiting after "stop" was called. I understand that this maybe desirable for some users so I left this as the default setting. The commit adds an option in the constructor to terminate the scheduler thread when stop is called. 